### PR TITLE
Support rabbit_peer_discovery_aws to work with IMDSv2

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1739,7 +1739,9 @@ end}.
 % ===============================
 
 %% @doc Whether or not to prefer EC2 IMDSv2 when querying instance metadata service.
-%% If not set or set to true, EC2 IMDSv2 will be preferred to use first. If fails, IEC2 MDSv1 will be used.
+%% The setting defaults to true. When true, instance metadata will first be attempted using EC2 IMDSv2
+%% and will fall back to EC2 IMDSv1 upon failure.
+%% When false, EC2 IMDSv1 will be used first and no attempt will be made to EC2 IMDSv2..
 %% See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
 
 {mapping, "aws.prefer_imdsv2", "rabbit.aws_prefer_imdsv2",

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1742,7 +1742,7 @@ end}.
 %% If not set or set to true, IMDSv2 will be preferred to use first. If fails, IMDSv1 will be used.
 %% {aws_prefer_imdsv2, false}
 
-{mapping, "aws_prefer_imdsv2", "rabbit.aws_prefer_imdsv2",
+{mapping, "aws.prefer_imdsv2", "rabbit.aws_prefer_imdsv2",
     [{datatype, {enum, [true, false]}}]}.
 
 

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1741,7 +1741,7 @@ end}.
 %% @doc Whether or not to prefer EC2 IMDSv2 when querying instance metadata service.
 %% The setting defaults to true. When true, instance metadata will first be attempted using EC2 IMDSv2
 %% and will fall back to EC2 IMDSv1 upon failure.
-%% When false, EC2 IMDSv1 will be used first and no attempt will be made to EC2 IMDSv2..
+%% When false, EC2 IMDSv1 will be used first and no attempt will be made to EC2 IMDSv2.
 %% See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
 
 {mapping, "aws.prefer_imdsv2", "rabbit.aws_prefer_imdsv2",

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1733,21 +1733,6 @@ end}.
     end
 }.
 
-
-% ===============================
-% AWS section
-% ===============================
-
-%% @doc Whether or not to prefer EC2 IMDSv2 when querying instance metadata service.
-%% The setting defaults to true. When true, instance metadata will first be attempted using EC2 IMDSv2
-%% and will fall back to EC2 IMDSv1 upon failure.
-%% When false, EC2 IMDSv1 will be used first and no attempt will be made to EC2 IMDSv2.
-%% See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
-
-{mapping, "aws.prefer_imdsv2", "rabbit.aws_prefer_imdsv2",
-    [{datatype, {enum, [true, false]}}]}.
-
-
 % ===============================
 % Validators
 % ===============================

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1733,6 +1733,19 @@ end}.
     end
 }.
 
+
+% ===============================
+% AWS section
+% ===============================
+
+%% Whether or not to prefer IMDSv2 when querying instance metadata service (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).
+%% If not set or set to true, IMDSv2 will be preferred to use first. If fails, IMDSv1 will be used.
+%% {aws_prefer_imdsv2, false}
+
+{mapping, "aws_prefer_imdsv2", "rabbit.aws_prefer_imdsv2",
+    [{datatype, {enum, [true, false]}}]}.
+
+
 % ===============================
 % Validators
 % ===============================

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1738,8 +1738,8 @@ end}.
 % AWS section
 % ===============================
 
-%% @doc Whether or not to prefer IMDSv2 when querying instance metadata service
-%% If not set or set to true, IMDSv2 will be preferred to use first. If fails, IMDSv1 will be used.
+%% @doc Whether or not to prefer EC2 IMDSv2 when querying instance metadata service.
+%% If not set or set to true, EC2 IMDSv2 will be preferred to use first. If fails, IEC2 MDSv1 will be used.
 %% See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
 
 {mapping, "aws.prefer_imdsv2", "rabbit.aws_prefer_imdsv2",

--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1738,9 +1738,9 @@ end}.
 % AWS section
 % ===============================
 
-%% Whether or not to prefer IMDSv2 when querying instance metadata service (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).
+%% @doc Whether or not to prefer IMDSv2 when querying instance metadata service
 %% If not set or set to true, IMDSv2 will be preferred to use first. If fails, IMDSv1 will be used.
-%% {aws_prefer_imdsv2, false}
+%% See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
 
 {mapping, "aws.prefer_imdsv2", "rabbit.aws_prefer_imdsv2",
     [{datatype, {enum, [true, false]}}]}.

--- a/deps/rabbitmq_aws/README.md
+++ b/deps/rabbitmq_aws/README.md
@@ -54,7 +54,7 @@ configuration or to impact configuration behavior:
  ``rabbitmq_aws:set_region/1``          | Manually specify the AWS region to make requests to.
  ``rabbitmq_aws:set_credentials/2``     | Manually specify the request credentials to use.
  ``rabbitmq_aws:refresh_credentials/0`` | Refresh the credentials from the environment, filesystem, or EC2 Instance Metadata service.
- ``rabbitmq_aws:ensure_imdsv2_token_valid/0`` | Make sure IMDSv2 token is acctive and valid.
+ ``rabbitmq_aws:ensure_imdsv2_token_valid/0`` | Make sure EC2 IMDSv2 token is active and valid.
  ``rabbitmq_aws:api_get_request/2``           | Perform an AWS service API request.
  ``rabbitmq_aws:get/2``                 | Perform a GET request to the API specifying the service and request path.
  ``rabbitmq_aws:get/3``                 | Perform a GET request specifying the service, path, and headers.

--- a/deps/rabbitmq_aws/README.md
+++ b/deps/rabbitmq_aws/README.md
@@ -26,6 +26,15 @@ The configuration values have the following precedence:
  - Configuration file
  - EC2 Instance Metadata Service where applicable
 
+### Credentials Precedence
+
+The credentials values have the following precedence:
+
+ - Explicitly configured via API
+ - Environment variables
+ - Credentials file
+ - EC2 Instance Metadata Service
+
 ### EC2 Instance Metadata Service Versions
 
 There are two versions of the EC2 Instance Metadata Service (IMDS) that are available by default on EC2 instances; IMDSv1 and IMDSv2 which is protected by session authentication

--- a/deps/rabbitmq_aws/README.md
+++ b/deps/rabbitmq_aws/README.md
@@ -34,7 +34,16 @@ The credentials values have the following precedence:
  - Environment variables
  - Credentials file
  - EC2 Instance Metadata Service
- 
+
+### EC2 Instance Metadata Service Versions
+
+There are two versions of the EC2 Instance Metadata Service that are available by default on EC2 instances; IMDSv1 and IMDSv2 which is protected by session authencation
+and [adds defenses against aditional vulnerabilities](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/).
+AWS recommends adopting IMDSv2 and disabling IMDSv1 [by configuring the Instance Metadata Service on the EC2 instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).
+
+By default *rabbitmq-aws* will attempt to use IMDSv2 first and will fallback to use IMDSv1 if calls to IMDSv2 fail. This behavior can be overridden
+by setting the ``aws_prefer_imdsv2`` setting to ``false``.
+
 ### Environment Variables
 
 As with the AWS CLI, the following environment variables can be used to provide 
@@ -67,7 +76,7 @@ configuration or to impact configuration behavior:
 ## Example Usage
 
 The following example assumes that you either have locally configured credentials or that
-you're using the AWS Instance Metadata service for credentials:
+you're using the EC2 Instance Metadata Service for credentials:
 
 ```erlang
 application:start(rabbitmq_aws).

--- a/deps/rabbitmq_aws/README.md
+++ b/deps/rabbitmq_aws/README.md
@@ -54,6 +54,8 @@ configuration or to impact configuration behavior:
  ``rabbitmq_aws:set_region/1``          | Manually specify the AWS region to make requests to.
  ``rabbitmq_aws:set_credentials/2``     | Manually specify the request credentials to use.
  ``rabbitmq_aws:refresh_credentials/0`` | Refresh the credentials from the environment, filesystem, or EC2 Instance Metadata service.
+ ``rabbitmq_aws:ensure_imdsv2_token_valid/0`` | Make sure IMDSv2 token is acctive and valid.
+ ``rabbitmq_aws:api_get_request/2``           | Perform an AWS service API request.
  ``rabbitmq_aws:get/2``                 | Perform a GET request to the API specifying the service and request path.
  ``rabbitmq_aws:get/3``                 | Perform a GET request specifying the service, path, and headers.
  ``rabbitmq_aws:post/4``                | Perform a POST request specifying the service, path, headers, and body.

--- a/deps/rabbitmq_aws/README.md
+++ b/deps/rabbitmq_aws/README.md
@@ -26,19 +26,10 @@ The configuration values have the following precedence:
  - Configuration file
  - EC2 Instance Metadata Service where applicable
 
-### Credentials Precedence
-
-The credentials values have the following precedence:
-
- - Explicitly configured via API
- - Environment variables
- - Credentials file
- - EC2 Instance Metadata Service
-
 ### EC2 Instance Metadata Service Versions
 
-There are two versions of the EC2 Instance Metadata Service (IMDS) that are available by default on EC2 instances; IMDSv1 and IMDSv2 which is protected by session authencation
-and [adds defenses against aditional vulnerabilities](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/).
+There are two versions of the EC2 Instance Metadata Service (IMDS) that are available by default on EC2 instances; IMDSv1 and IMDSv2 which is protected by session authentication
+and [adds defenses against additional vulnerabilities](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/).
 AWS recommends adopting IMDSv2 and disabling IMDSv1 [by configuring the Instance Metadata Service on the EC2 instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).
 
 By default *rabbitmq-aws* will attempt to use IMDSv2 first and will fallback to use IMDSv1 if calls to IMDSv2 fail. This behavior can be overridden
@@ -62,7 +53,7 @@ configuration or to impact configuration behavior:
  ---------------------------------------|--------------------------------------------------------------------------------------------
  ``rabbitmq_aws:set_region/1``          | Manually specify the AWS region to make requests to.
  ``rabbitmq_aws:set_credentials/2``     | Manually specify the request credentials to use.
- ``rabbitmq_aws:refresh_credentials/0`` | Refresh the credentials from the environment, filesystem, or EC2 Instance Metadata service.
+ ``rabbitmq_aws:refresh_credentials/0`` | Refresh the credentials from the environment, filesystem, or EC2 Instance Metadata Service.
  ``rabbitmq_aws:ensure_imdsv2_token_valid/0`` | Make sure EC2 IMDSv2 token is active and valid.
  ``rabbitmq_aws:api_get_request/2``           | Perform an AWS service API request.
  ``rabbitmq_aws:get/2``                 | Perform a GET request to the API specifying the service and request path.

--- a/deps/rabbitmq_aws/README.md
+++ b/deps/rabbitmq_aws/README.md
@@ -37,7 +37,7 @@ The credentials values have the following precedence:
 
 ### EC2 Instance Metadata Service Versions
 
-There are two versions of the EC2 Instance Metadata Service that are available by default on EC2 instances; IMDSv1 and IMDSv2 which is protected by session authencation
+There are two versions of the EC2 Instance Metadata Service (IMDS) that are available by default on EC2 instances; IMDSv1 and IMDSv2 which is protected by session authencation
 and [adds defenses against aditional vulnerabilities](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/).
 AWS recommends adopting IMDSv2 and disabling IMDSv1 [by configuring the Instance Metadata Service on the EC2 instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html).
 

--- a/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
+++ b/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
@@ -33,13 +33,13 @@
 
 -define(TOKEN_URL, "latest/api/token").
 
--define(METADATA_TOKEN_TLL_HEADER, "X-aws-ec2-metadata-token-ttl-seconds").
+-define(METADATA_TOKEN_TTL_HEADER, "X-aws-ec2-metadata-token-ttl-seconds").
 
 % EC2 Instance Metadata service version 2 (IMDSv2) uses session-oriented authentication.
 % Instance metadata service requests are only needed for loading/refreshing credentials.
 % Long-lived EC2 IMDSv2 tokens are unnecessary. The token only needs to be valid long enough
-% to successfully load/refresh the credentials. 60 seconds is more than enough time to accomplish this..
--define(METADATA_TOKEN_TLL_SECONDS, 60).
+% to successfully load/refresh the credentials. 60 seconds is more than enough time to accomplish this.
+-define(METADATA_TOKEN_TTL_SECONDS, 60).
 
 -define(METADATA_TOKEN, "X-aws-ec2-metadata-token").
 

--- a/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
+++ b/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
@@ -35,8 +35,10 @@
 
 -define(METADATA_TOKEN_TLL_HEADER, "X-aws-ec2-metadata-token-ttl-seconds").
 
-% AWS IMDSv2 is session-based and instance metadata service requests which are only needed for loading/refreshing credentials.
-% We dont need to have long-live metadata token. In fact, we only need the token is valid for a sufficient period to successfully
+% EC2 Instance Metadata service version 2 (IMDSv2) uses session-oriented authentication.
+% Instance metadata service requests are only needed for loading/refreshing credentials.
+% We dont need to have long-live metadata token.
+% In fact, we only need the token is valid for a sufficient period to successfully
 % load/refresh credentials. 60 seconds is more than enough for that goal.
 -define(METADATA_TOKEN_TLL_SECONDS, 60).
 

--- a/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
+++ b/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
@@ -29,6 +29,18 @@
 
 -define(INSTANCE_CREDENTIALS, "iam/security-credentials").
 -define(INSTANCE_METADATA_BASE, "latest/meta-data").
+-define(INSTANCE_ID, "instance-id").
+
+-define(TOKEN_URL, "latest/api/token").
+
+-define(METADATA_TOKEN_TLL_HEADER, "X-aws-ec2-metadata-token-ttl-seconds").
+
+% AWS IMDSv2 is session-based and instance metadata service requests which are only needed for loading/refreshing credentials.
+% We dont need to have long-live metadata token. In fact, we only need the token is valid for a sufficient period to successfully
+% load/refresh credentials. 60 seconds is more than enough for that goal.
+-define(METADATA_TOKEN_TLL_SECONDS, 60).
+
+-define(METADATA_TOKEN, "X-aws-ec2-metadata-token").
 
 -type access_key() :: nonempty_string().
 -type secret_access_key() :: nonempty_string().
@@ -41,11 +53,17 @@
 -type sc_error() :: {error, Reason :: atom()}.
 -type security_credentials() :: sc_ok() | sc_error().
 
+-record(imdsv2token, { token :: security_token() | undefined,
+                       expiration :: expiration() | undefined}).
+
+-type imdsv2token() :: #imdsv2token{}.
+
 -record(state, {access_key :: access_key() | undefined,
                 secret_access_key :: secret_access_key() | undefined,
                 expiration :: expiration() | undefined,
                 security_token :: security_token() | undefined,
                 region :: region() | undefined,
+                imdsv2_token:: imdsv2token() | undefined,
                 error :: atom() | string() | undefined}).
 -type state() :: #state{}.
 

--- a/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
+++ b/deps/rabbitmq_aws/include/rabbitmq_aws.hrl
@@ -37,9 +37,8 @@
 
 % EC2 Instance Metadata service version 2 (IMDSv2) uses session-oriented authentication.
 % Instance metadata service requests are only needed for loading/refreshing credentials.
-% We dont need to have long-live metadata token.
-% In fact, we only need the token is valid for a sufficient period to successfully
-% load/refresh credentials. 60 seconds is more than enough for that goal.
+% Long-lived EC2 IMDSv2 tokens are unnecessary. The token only needs to be valid long enough
+% to successfully load/refresh the credentials. 60 seconds is more than enough time to accomplish this..
 -define(METADATA_TOKEN_TLL_SECONDS, 60).
 
 -define(METADATA_TOKEN, "X-aws-ec2-metadata-token").

--- a/deps/rabbitmq_aws/priv/schema/rabbitmq_aws.schema
+++ b/deps/rabbitmq_aws/priv/schema/rabbitmq_aws.schema
@@ -1,0 +1,13 @@
+
+% ===============================
+% AWS section
+% ===============================
+
+%% @doc Whether or not to prefer EC2 IMDSv2 when querying instance metadata service.
+%% The setting defaults to true. When true, instance metadata will first be attempted using EC2 IMDSv2
+%% and will fall back to EC2 IMDSv1 upon failure.
+%% When false, EC2 IMDSv1 will be used first and no attempt will be made to EC2 IMDSv2.
+%% See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
+
+{mapping, "aws.prefer_imdsv2", "rabbit.aws_prefer_imdsv2",
+    [{datatype, {enum, [true, false]}}]}.

--- a/deps/rabbitmq_aws/priv/schema/rabbitmq_aws.schema
+++ b/deps/rabbitmq_aws/priv/schema/rabbitmq_aws.schema
@@ -6,7 +6,7 @@
 %% @doc Whether or not to prefer EC2 IMDSv2 when querying instance metadata service.
 %% The setting defaults to true. When true, instance metadata will first be attempted using EC2 IMDSv2
 %% and will fall back to EC2 IMDSv1 upon failure.
-%% When false, EC2 IMDSv1 will be used first and no attempt will be made to EC2 IMDSv2.
+%% When false, EC2 IMDSv1 will be used first and no attempt will be made to use EC2 IMDSv2.
 %% See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html.
 
 {mapping, "aws.prefer_imdsv2", "rabbit.aws_prefer_imdsv2",

--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -164,7 +164,7 @@ set_imdsv2_token(Imdsv2Token) ->
 %% @doc return the current Imdsv2Token used to perform instance metadata service requests.
 %% @end
 get_imdsv2_token() ->
-  {ok, Imdsv2Token}=gen_server:call(rabbitmq_aws, get_imdsv2_token),
+  {ok, Imdsv2Token} = gen_server:call(rabbitmq_aws, get_imdsv2_token),
   Imdsv2Token.
 
 
@@ -513,10 +513,10 @@ expired_imdsv2_token({_, _, Expiration}) ->
 
 -spec ensure_imdsv2_token_valid() -> imdsv2token().
 ensure_imdsv2_token_valid() ->
-  Imdsv2Token=get_imdsv2_token(),
+  Imdsv2Token = get_imdsv2_token(),
   case expired_imdsv2_token(Imdsv2Token) of
-    true -> Value=rabbitmq_aws_config:load_imdsv2_token(),
-            Expiration=calendar:datetime_to_gregorian_seconds(local_time()) + ?METADATA_TOKEN_TTL_SECONDS,
+    true -> Value = rabbitmq_aws_config:load_imdsv2_token(),
+            Expiration = calendar:datetime_to_gregorian_seconds(local_time()) + ?METADATA_TOKEN_TTL_SECONDS,
             set_imdsv2_token(#imdsv2token{token = Value,
                                           expiration = Expiration}),
             Value;
@@ -530,7 +530,7 @@ ensure_imdsv2_token_valid() ->
 %% @end
 ensure_credentials_valid() ->
   rabbit_log:debug("Making sure AWS credentials are available and still valid."),
-  {ok, State}=gen_server:call(rabbitmq_aws, get_state),
+  {ok, State} = gen_server:call(rabbitmq_aws, get_state),
   case has_credentials(State) of
     true -> case expired_credentials(State#state.expiration) of
               true -> refresh_credentials(State);

--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -79,6 +79,7 @@ post(Service, Path, Body, Headers) ->
 refresh_credentials() ->
   gen_server:call(rabbitmq_aws, refresh_credentials).
 
+
 -spec refresh_credentials(state()) -> ok | error.
 %% @doc Manually refresh the credentials from the environment, filesystem or EC2
 %%      Instance metadata service.
@@ -86,7 +87,9 @@ refresh_credentials() ->
 refresh_credentials(State) ->
   rabbit_log:debug("Refreshing AWS credentials..."),
   {_, NewState} = load_credentials(State),
+  rabbit_log:debug("AWS credentials has been refreshed."),
   set_credentials(NewState).
+
 
 -spec request(Service :: string(),
               Method :: method(),
@@ -496,15 +499,15 @@ sign_headers(#state{access_key = AccessKey,
 %% @doc Determine whether an Imdsv2Token has expired or not.
 %% @end
 expired_imdsv2_token(undefined) ->
-  rabbit_log:debug("AWS Imdsv2 token has not been obtained yet."),
+  rabbit_log:debug("EC2 IMDSv2 token has not yet been obtained."),
   true;
 expired_imdsv2_token({_, _, undefined}) ->
-  rabbit_log:debug("AWS Imdsv2 token is not available."),
+  rabbit_log:debug("EC2 IMDSv2 token is not available."),
   true;
 expired_imdsv2_token({_, _, Expiration}) ->
   Now = calendar:datetime_to_gregorian_seconds(local_time()),
   HasExpired = Now >= Expiration,
-  rabbit_log:debug("AWS Imdsv2 token has expired: ~p", [HasExpired]),
+  rabbit_log:debug("EC2 IMDSv2 token has expired: ~p", [HasExpired]),
   HasExpired.
 
 

--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -87,7 +87,7 @@ refresh_credentials() ->
 refresh_credentials(State) ->
   rabbit_log:debug("Refreshing AWS credentials..."),
   {_, NewState} = load_credentials(State),
-  rabbit_log:debug("AWS credentials has been refreshed."),
+  rabbit_log:debug("AWS credentials have been refreshed."),
   set_credentials(NewState).
 
 
@@ -496,7 +496,7 @@ sign_headers(#state{access_key = AccessKey,
                                   body = Body}).
 
 -spec expired_imdsv2_token(imdsv2token()) -> boolean().
-%% @doc Determine whether an Imdsv2Token has expired or not.
+%% @doc Determine whether or not an Imdsv2Token has expired..
 %% @end
 expired_imdsv2_token(undefined) ->
   rabbit_log:debug("EC2 IMDSv2 token has not yet been obtained."),
@@ -524,13 +524,12 @@ ensure_imdsv2_token_valid() ->
   end.
 
 -spec ensure_credentials_valid() -> ok.
-%% @doc Invoked before each AWS service API request checking to see if credentials available
-%%      or whether the current credentials have expired.
-%%      If they haven't, move on performing the request, otherwise try and refresh the
-%%      credentials before performing the request.
+%% @doc Invoked before each AWS service API request to check if the current credentials are available and that they have not expired.
+%%      If the credentials are available and are still current, then move on and perform the request.
+%%      If the credentials are not available or have expired, then refresh them before performing the request.
 %% @end
 ensure_credentials_valid() ->
-  rabbit_log:debug("Making sure AWS credentials is available and still valid."),
+  rabbit_log:debug("Making sure AWS credentials are available and still valid."),
   {ok, State}=gen_server:call(rabbitmq_aws, get_state),
   case has_credentials(State) of
     true -> case expired_credentials(State#state.expiration) of

--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -73,16 +73,14 @@ post(Service, Path, Body, Headers) ->
 
 
 -spec refresh_credentials() -> ok | error.
-%% @doc Manually refresh the credentials from the environment, filesystem or EC2
-%%      Instance metadata service.
+%% @doc Manually refresh the credentials from the environment, filesystem or EC2 Instance Metadata Service.
 %% @end
 refresh_credentials() ->
   gen_server:call(rabbitmq_aws, refresh_credentials).
 
 
 -spec refresh_credentials(state()) -> ok | error.
-%% @doc Manually refresh the credentials from the environment, filesystem or EC2
-%%      Instance metadata service.
+%% @doc Manually refresh the credentials from the environment, filesystem or EC2 Instance Metadata Service.
 %% @end
 refresh_credentials(State) ->
   rabbit_log:debug("Refreshing AWS credentials..."),

--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -496,7 +496,7 @@ sign_headers(#state{access_key = AccessKey,
                                   body = Body}).
 
 -spec expired_imdsv2_token(imdsv2token()) -> boolean().
-%% @doc Determine whether or not an Imdsv2Token has expired..
+%% @doc Determine whether or not an Imdsv2Token has expired.
 %% @end
 expired_imdsv2_token(undefined) ->
   rabbit_log:debug("EC2 IMDSv2 token has not yet been obtained."),
@@ -516,7 +516,7 @@ ensure_imdsv2_token_valid() ->
   Imdsv2Token=get_imdsv2_token(),
   case expired_imdsv2_token(Imdsv2Token) of
     true -> Value=rabbitmq_aws_config:load_imdsv2_token(),
-            Expiration=calendar:datetime_to_gregorian_seconds(local_time()) + ?METADATA_TOKEN_TLL_SECONDS,
+            Expiration=calendar:datetime_to_gregorian_seconds(local_time()) + ?METADATA_TOKEN_TTL_SECONDS,
             set_imdsv2_token(#imdsv2token{token = Value,
                                           expiration = Expiration}),
             Value;

--- a/deps/rabbitmq_aws/src/rabbitmq_aws.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws.erl
@@ -154,14 +154,14 @@ set_region(Region) ->
   gen_server:call(rabbitmq_aws, {set_region, Region}).
 
 -spec set_imdsv2_token(imdsv2token()) -> ok.
-%% @doc Manually set the Imdsv2Token to perform instance metadata service requests.
+%% @doc Manually set the Imdsv2Token used to perform instance metadata service requests.
 %% @end
 set_imdsv2_token(Imdsv2Token) ->
   gen_server:call(rabbitmq_aws, {set_imdsv2_token, Imdsv2Token}).
 
 
 -spec get_imdsv2_token() -> imdsv2token().
-%% @doc return the current Imdsv2Token to perform instance metadata service requests.
+%% @doc return the current Imdsv2Token used to perform instance metadata service requests.
 %% @end
 get_imdsv2_token() ->
   {ok, Imdsv2Token}=gen_server:call(rabbitmq_aws, get_imdsv2_token),

--- a/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
@@ -625,15 +625,14 @@ parse_az_response({ok, {{_, _, _}, _, _}}) -> {error, undefined}.
 %% @doc Parse the return response from the Instance Metadata service where the
 %%      body value is the string to process.
 %% end.
-
-parse_body_response({error, {{_, 401, _}, _, _}}) ->
-  rabbit_log:error("Unauthorized instance metadata service request - The GET request uses an invalid token."),
-  {error, undefined};
-parse_body_response({error, {{_, 403, _}, _, _}}) ->
-  rabbit_log:error("The request is not allowed or the instance metadata service is turned off."),
-  {error, undefined};
 parse_body_response({error, _}) -> {error, undefined};
 parse_body_response({ok, {{_, 200, _}, _, Body}}) -> {ok, Body};
+parse_body_response({ok, {{_, 401, _}, _, _}}) ->
+  rabbit_log:error("Unauthorized instance metadata service request."),
+  {error, undefined};
+parse_body_response({ok, {{_, 403, _}, _, _}}) ->
+  rabbit_log:error("The request is not allowed or the instance metadata service is turned off."),
+  {error, undefined};
 parse_body_response({ok, {{_, _, _}, _, _}}) -> {error, undefined}.
 
 

--- a/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
@@ -621,13 +621,13 @@ parse_az_response({ok, {{_, _, _}, _, _}}) -> {error, undefined}.
 
 -spec parse_body_response(httpc_result())
  -> {ok, Value :: string()} | {error, Reason :: atom()}.
-%% @doc Parse the return response from the Instance Metadata service where the
+%% @doc Parse the return response from the Instance Metadata Service where the
 %%      body value is the string to process.
 %% end.
 parse_body_response({error, _}) -> {error, undefined};
 parse_body_response({ok, {{_, 200, _}, _, Body}}) -> {ok, Body};
 parse_body_response({ok, {{_, 401, _}, _, _}}) ->
-  rabbit_log:error(get_instruction_on_instance_metadata_error("Unauthorized instance metadata service request. ")),
+  rabbit_log:error(get_instruction_on_instance_metadata_error("Unauthorized instance metadata service request.")),
   {error, undefined};
 parse_body_response({ok, {{_, 403, _}, _, _}}) ->
   rabbit_log:error(get_instruction_on_instance_metadata_error("The request is not allowed or the instance metadata service is turned off.")),
@@ -667,7 +667,7 @@ perform_http_get_instance_metadata(URL) ->
     [{timeout, ?DEFAULT_HTTP_TIMEOUT}], []).
 
 -spec get_instruction_on_instance_metadata_error(string()) -> string().
-%% @doc Return error message on failures related to instance metadata service with a reference to AWS document.
+%% @doc Return error message on failures related to EC2 Instance Metadata Service with a reference to AWS document.
 %% end
 get_instruction_on_instance_metadata_error(ErrorMessage) ->
   ErrorMessage ++
@@ -770,12 +770,12 @@ instance_metadata_request_headers() ->
   case application:get_env(rabbit, aws_prefer_imdsv2) of
     {ok, false} -> [];
     _           -> %% undefined or {ok, true}
-                   rabbit_log:debug("EC2 instance metadata service v2 (IMDSv2) is preferred."),
+                   rabbit_log:debug("EC2 Instance Metadata Service v2 (IMDSv2) is preferred."),
                    maybe_imdsv2_token_headers()
   end.
 
 -spec maybe_imdsv2_token_headers() -> headers().
-%% @doc Construct http request headers from Imdsv2Token to use with GET requests submitted to the instance metadata service.
+%% @doc Construct http request headers from Imdsv2Token to use with GET requests submitted to the EC2 Instance Metadata Service.
 %% @end
 maybe_imdsv2_token_headers() ->
   case rabbitmq_aws:ensure_imdsv2_token_valid() of

--- a/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
@@ -747,7 +747,7 @@ region_from_availability_zone(Value) ->
 load_imdsv2_token() ->
   TokenUrl=imdsv2_token_url(),
   rabbit_log:info("Attempting to obtain EC2 IMDSv2 token from ~p ...", [TokenUrl]),
-  case httpc:request(put, {TokenUrl, [{?METADATA_TOKEN_TLL_HEADER, integer_to_list(?METADATA_TOKEN_TLL_SECONDS)}]},
+  case httpc:request(put, {TokenUrl, [{?METADATA_TOKEN_TTL_HEADER, integer_to_list(?METADATA_TOKEN_TTL_SECONDS)}]},
     [{timeout, ?DEFAULT_HTTP_TIMEOUT}], []) of
     {ok, {{_, 200, _}, _, Value}} ->
       rabbit_log:debug("Successfully obtained EC2 IMDSv2 token."),

--- a/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
@@ -751,7 +751,7 @@ load_imdsv2_token() ->
     Other ->
       rabbit_log:warning("Failed to obtain EC2 IMDSv2 token: ~p. "
                          "It is recommended to use EC2 IMDSv2. "
-                         "Please refer to AWS public document fordetail on how to configure instance metadata: "
+                         "Please refer to AWS public document for detail on how to configure instance metadata: "
                          "https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html."
                          "Fallback to use EC2 IMDSv1 for now.", [Other]),
       undefined
@@ -765,7 +765,7 @@ instance_metadata_request_headers() ->
   case application:get_env(rabbit, aws_prefer_imdsv2) of
     {ok, false} -> [];
     _           -> %% undefined or {ok, true}
-                   rabbit_log:debug("AWS Instance metadata service v2 (IMDSv2) is preferred."),
+                   rabbit_log:debug("EC2 instance metadata service v2 (IMDSv2) is preferred."),
                    maybe_imdsv2_token_headers()
   end.
 

--- a/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
@@ -426,14 +426,13 @@ instance_role_url() ->
   instance_metadata_url(string:join([?INSTANCE_METADATA_BASE, ?INSTANCE_CREDENTIALS], "/")).
 
 -spec imdsv2_token_url() -> string().
-%% @doc Return the URL for obtaining IMDSv2 token from the Instance Metadata service
+%% @doc Return the URL for obtaining IMDSv2 token from the Instance Metadata service.
 %% @end
 imdsv2_token_url() ->
   instance_metadata_url(?TOKEN_URL).
 
 -spec instance_id_url() -> string().
-%% @doc Return the URL for querying the id of the current
-%%      instance from the Instance Metadata service.
+%% @doc Return the URL for querying the id of the current instance from the Instance Metadata service.
 %% @end
 instance_id_url() ->
   instance_metadata_url(string:join([?INSTANCE_METADATA_BASE, ?INSTANCE_ID], "/")).
@@ -735,7 +734,7 @@ region_from_availability_zone(Value) ->
 
 
 -spec load_imdsv2_token() -> security_token().
-%% @doc Attempt to obtain IMDSv2 token.
+%% @doc Attempt to obtain EC2 IMDSv2 token.
 %% @end
 load_imdsv2_token() ->
   TokenUrl=imdsv2_token_url(),

--- a/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
+++ b/deps/rabbitmq_aws/src/rabbitmq_aws_config.erl
@@ -745,7 +745,7 @@ region_from_availability_zone(Value) ->
 %% @doc Attempt to obtain EC2 IMDSv2 token.
 %% @end
 load_imdsv2_token() ->
-  TokenUrl=imdsv2_token_url(),
+  TokenUrl = imdsv2_token_url(),
   rabbit_log:info("Attempting to obtain EC2 IMDSv2 token from ~p ...", [TokenUrl]),
   case httpc:request(put, {TokenUrl, [{?METADATA_TOKEN_TTL_HEADER, integer_to_list(?METADATA_TOKEN_TTL_SECONDS)}]},
     [{timeout, ?DEFAULT_HTTP_TIMEOUT}], []) of

--- a/deps/rabbitmq_aws/test/src/rabbitmq_aws_config_tests.erl
+++ b/deps/rabbitmq_aws/test/src/rabbitmq_aws_config_tests.erl
@@ -362,14 +362,14 @@ instance_id_test_() ->
           ?assertEqual({ok, "instance-id"}, rabbitmq_aws_config:instance_id())
         end
       },
-      {"failed to get instance id - invalid token",
+      {"getting instance id is rejected with invalid token error",
         fun() ->
           meck:expect(rabbitmq_aws, ensure_imdsv2_token_valid, 0, "invalid"),
           meck:expect(httpc, request, 4, {error, {{protocol, 401, message}, headers, "Invalid token"}}),
           ?assertEqual({error, undefined}, rabbitmq_aws_config:instance_id())
         end
       },
-      {"failed to get instance id - access denied",
+      {"getting instance id is rejected with access denied error",
         fun() ->
           meck:expect(rabbitmq_aws, ensure_imdsv2_token_valid, 0, "expired token"),
           meck:expect(httpc, request, 4, {error, {{protocol, 403, message}, headers, "access denied"}}),

--- a/deps/rabbitmq_aws/test/src/rabbitmq_aws_tests.erl
+++ b/deps/rabbitmq_aws/test/src/rabbitmq_aws_tests.erl
@@ -218,7 +218,7 @@ gen_server_call_test_() ->
           ?assertEqual({reply, ok, State},
                        rabbitmq_aws:handle_call({set_credentials,
                                               State#state.access_key,
-                                              State#state.secret_access_key}, eunit, #state{region="us-west-3"}))
+                                              State#state.secret_access_key}, eunit, #state{region = "us-west-3"}))
         end
       },
       {
@@ -395,7 +395,7 @@ perform_request_test_() ->
           Options = [],
           Host = undefined,
           meck:expect(rabbitmq_aws_config, credentials, fun() -> {error, unit_test} end),
-          Expectation = {{error, {credentials, "Credentials expired!"}}, State#state{error="Credentials expired!"}},
+          Expectation = {{error, {credentials, "Credentials expired!"}}, State#state{error = "Credentials expired!"}},
           Result = rabbitmq_aws:perform_request(State, Service, Method, Headers, Path, Body, Options, Host),
           ?assertEqual(Expectation, Result),
           meck:validate(rabbitmq_aws_config)

--- a/deps/rabbitmq_aws/test/src/rabbitmq_aws_tests.erl
+++ b/deps/rabbitmq_aws/test/src/rabbitmq_aws_tests.erl
@@ -507,7 +507,7 @@ ensure_credentials_valid_test_() ->
     end,
     fun meck:unload/1,
     [
-      {"expired credentials is refreshed",
+      {"expired credentials are refreshed",
         fun() ->
           State = #state{access_key = "ExpiredKey",
                         secret_access_key = "ExpiredAccessKey",
@@ -536,7 +536,7 @@ ensure_credentials_valid_test_() ->
           ?assertEqual(Credentials, {ok, State2}),
           meck:validate(rabbitmq_aws_config)
         end},
-      {"valid credentials is returned",
+      {"valid credentials are returned",
         fun() ->
           State = #state{access_key = "GoodKey",
                          secret_access_key = "GoodAccessKey",

--- a/deps/rabbitmq_peer_discovery_aws/src/rabbit_peer_discovery_aws.erl
+++ b/deps/rabbitmq_peer_discovery_aws/src/rabbit_peer_discovery_aws.erl
@@ -90,7 +90,7 @@ list_nodes() ->
             case rabbitmq_aws_config:instance_id() of
                 {ok, InstanceId} -> rabbit_log:debug("EC2 instance ID is determined from metadata service: ~p", [InstanceId]),
                                     get_autoscaling_group_node_list(InstanceId, get_tags());
-                _                -> {error, "Failed to determined EC2 instance ID from metadata service"}
+                _                -> {error, "Failed to determine EC2 instance ID from metadata service"}
             end;
         false ->
             get_node_list_from_tags(get_tags())

--- a/deps/rabbitmq_peer_discovery_aws/src/rabbit_peer_discovery_aws.erl
+++ b/deps/rabbitmq_peer_discovery_aws/src/rabbit_peer_discovery_aws.erl
@@ -87,9 +87,11 @@ list_nodes() ->
                                get_config_key(aws_secret_key, M)),
     case get_config_key(aws_autoscaling, M) of
         true ->
-            {ok, InstanceId} = rabbitmq_aws_config:instance_id(),
-            rabbit_log:debug("EC2 instance ID is determined from metadata service: ~p", [InstanceId]),
-            get_autoscaling_group_node_list(InstanceId, get_tags());
+            case rabbitmq_aws_config:instance_id() of
+                {ok, InstanceId} -> rabbit_log:debug("EC2 instance ID is determined from metadata service: ~p", [InstanceId]),
+                                    get_autoscaling_group_node_list(InstanceId, get_tags());
+                _                -> {error, "Failed to determined EC2 instance ID from metadata service"}
+            end;
         false ->
             get_node_list_from_tags(get_tags())
     end.

--- a/deps/rabbitmq_peer_discovery_aws/src/rabbit_peer_discovery_aws.erl
+++ b/deps/rabbitmq_peer_discovery_aws/src/rabbit_peer_discovery_aws.erl
@@ -23,16 +23,6 @@
 -compile(export_all).
 -endif.
 
-% rabbitmq/rabbitmq-peer-discovery-aws#25
-
-% Note: this timeout must not be greater than the default
-% gen_server:call timeout of 5000ms. Note that `timeout`,
-% when set, is used as the connect and then request timeout
-% by `httpc`
--define(INSTANCE_ID_TIMEOUT, 2250).
--define(INSTANCE_ID_URL,
-        "http://169.254.169.254/latest/meta-data/instance-id").
-
 -define(CONFIG_MODULE, rabbit_peer_discovery_config).
 -define(UTIL_MODULE,   rabbit_peer_discovery_util).
 
@@ -91,14 +81,15 @@ init() ->
 list_nodes() ->
     M = ?CONFIG_MODULE:config_map(?BACKEND_CONFIG_KEY),
     {ok, _} = application:ensure_all_started(rabbitmq_aws),
-    rabbit_log:debug("Started rabbitmq_aws"),
     rabbit_log:debug("Will use AWS access key of '~s'", [get_config_key(aws_access_key, M)]),
     ok = maybe_set_region(get_config_key(aws_ec2_region, M)),
     ok = maybe_set_credentials(get_config_key(aws_access_key, M),
                                get_config_key(aws_secret_key, M)),
     case get_config_key(aws_autoscaling, M) of
         true ->
-            get_autoscaling_group_node_list(instance_id(), get_tags());
+            {ok, InstanceId} = rabbitmq_aws_config:instance_id(),
+            rabbit_log:debug("EC2 instance ID is determined from metadata service: ~p", [InstanceId]),
+            get_autoscaling_group_node_list(InstanceId, get_tags());
         false ->
             get_node_list_from_tags(get_tags())
     end.
@@ -160,14 +151,18 @@ maybe_set_credentials(AccessKey, SecretKey) ->
 %% @doc Set the region from the configuration value, if it was set.
 %% @end
 %%
-maybe_set_region("undefined") -> ok;
+maybe_set_region("undefined") ->
+    case rabbitmq_aws_config:region() of
+        {ok, Region} -> maybe_set_region(Region);
+        _            -> ok
+    end;
 maybe_set_region(Value) ->
     rabbit_log:debug("Setting AWS region to ~p", [Value]),
     rabbitmq_aws:set_region(Value).
 
 get_autoscaling_group_node_list(error, _) ->
     rabbit_log:warning("Cannot discover any nodes: failed to fetch this node's EC2 "
-                       "instance id from ~s", [?INSTANCE_ID_URL]),
+                       "instance id from ~s", rabbitmq_aws_config:instance_id_url()),
     {ok, {[], disc}};
 get_autoscaling_group_node_list(Instance, Tag) ->
     case get_all_autoscaling_instances([]) of
@@ -222,7 +217,7 @@ get_all_autoscaling_instances(Accum, NextToken) ->
 
 fetch_all_autoscaling_instances(QArgs, Accum) ->
     Path = "/?" ++ rabbitmq_aws_urilib:build_query_string(QArgs),
-    case api_get_request("autoscaling", Path) of
+    case rabbitmq_aws:api_get_request("autoscaling", Path) of
         {ok, Payload} ->
             Instances = flatten_autoscaling_datastructure(Payload),
             NextToken = get_next_token(Payload),
@@ -243,16 +238,6 @@ get_next_token(Value) ->
     Result = proplists:get_value("DescribeAutoScalingInstancesResult", Response),
     NextToken = proplists:get_value("NextToken", Result),
     NextToken.
-
-api_get_request(Service, Path) ->
-    case rabbitmq_aws:get(Service, Path) of
-        {ok, {_Headers, Payload}} ->
-            rabbit_log:debug("AWS request: ~s~nResponse: ~p",
-                             [Path, Payload]),
-            {ok, Payload};
-        {error, {credentials, _}} -> {error, credentials};
-        {error, Message, _} -> {error, Message}
-    end.
 
 -spec find_autoscaling_group(Instances :: list(), Instance :: string())
                             -> string() | error.
@@ -320,7 +305,7 @@ get_hostname_name_from_reservation_set([{"item", RI}|T], Accum) ->
     get_hostname_name_from_reservation_set(T, Accum ++ Hostnames).
 
 get_hostname_names(Path) ->
-    case api_get_request("ec2", Path) of
+    case rabbitmq_aws:api_get_request("ec2", Path) of
         {ok, Payload} ->
             Response = proplists:get_value("DescribeInstancesResponse", Payload),
             ReservationSet = proplists:get_value("reservationSet", Response),
@@ -349,24 +334,6 @@ select_hostname() ->
         true  -> "privateIpAddress";
         false -> "privateDnsName";
         _     -> "privateDnsName"
-    end.
-
--spec instance_id() -> string() | error.
-%% @private
-%% @doc Return the local instance ID from the EC2 metadata service
-%% @end
-%%
-instance_id() ->
-    case httpc:request(get, {?INSTANCE_ID_URL, []},
-                       [{timeout, ?INSTANCE_ID_TIMEOUT}], []) of
-        {ok, {{_, 200, _}, _, Value}} ->
-            rabbit_log:debug("Fetched EC2 instance ID from ~p: ~p",
-                             [?INSTANCE_ID_URL, Value]),
-            Value;
-        Other ->
-            rabbit_log:error("Failed to fetch EC2 instance ID from ~p: ~p",
-                             [?INSTANCE_ID_URL, Other]),
-            error
     end.
 
 -spec get_tags() -> tags().


### PR DESCRIPTION
AWS EC2 Instance Metadata service version 2 (IMDSv2) uses session-oriented requests. With session-oriented requests, a session token is retrieved first
then used in subsequent GET requests for instance metadata values such as instance-id, credentials, etc.

Details could be found here https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

## Proposed Changes

The following change is an implementation to the support aws_peer_discover_aws plugin to work with EC2 instance metadata service version 2 (IMDSv2). IMDSv2 is a new version of the instance metadata service which adds defense in depth against open firewalls, reverse proxies, and SSRF vulnerabilities. With IMDSv2, every request submitted to the instance metadata service is now protected by session authentication. Specifically, querying IMDSv2 is done in 2 steps:
* Start a session with an HTTP PUT request to IMDSv2. IMDSv2 then returns a secret token.
* Use the secret token to make any HTTP GET request to retrieve interested metadata values such as availability zone, instance role, instance ID, credentials, etc.

This change is backward compatible. If for some reason, it fails to obtain a secret token from IMDSv2, rabbit_peer_discovery_aws plugin will fallback to use IMDSv1.

Per AWS security recommendation, IMDSv2 is preferable. A new configuration flag `aws_prefer_imdsv2` is also introduced to allow users explicitly disable using IMDSv1. Specifically, if the configuration flag `aws_prefer_imdsv2` is not set or set to true, the rabbitmq_peer_discovery_aws plugin will attempt to retrieve a secret token first. If a secret token is received successfully, it will be used in subsequent requests submitted to the instance metadata service. On the other hand, if  `aws_prefer_imdsv2` is set to false, the rabbitmq_peer_discovery_aws plugin will only use IMDSv1 for instance metadata queries. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have tested this change with AWS.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

IMDSv2 secret token retrieval result (both success and failure) is cached and reused. This is to guarantee that there is at most 1 HTTP PUT request is used to request IMDSv2 secret token per session which included multiple HTTP GET requests to query metadata values: instance-id, availability zone, instance role, and credentials.
