### PR TITLE
Obfuscate credentials in shovel worker states to avoid plaintext pass…

### DIFF
--- a/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_dyn_worker_sup_sup.erl
@@ -42,7 +42,7 @@ start_child({VHost, ShovelName} = Name, Def) ->
     rabbit_log_shovel:debug("Starting a mirrored supervisor named '~s' in virtual host '~s'", [ShovelName, VHost]),
     Result = case mirrored_supervisor:start_child(
            ?SUPERVISOR,
-           {Name, {rabbit_shovel_dyn_worker_sup, start_link, [Name, Def]},
+           {Name, {rabbit_shovel_dyn_worker_sup, start_link, [Name, rabbit_shovel_parameters:obfuscate_uris_parameters(Def)]},
             transient, ?WORKER_WAIT, worker, [rabbit_shovel_dyn_worker_sup]}) of
         {ok,                      _Pid}  -> ok;
         {error, {already_started, _Pid}} -> ok

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
@@ -13,8 +13,9 @@
 
 -export([validate/5, notify/5, notify_clear/4]).
 -export([register/0, unregister/0, parse/3]).
+-export([obfuscate_uris_parameters/1]).
 
--import(rabbit_misc, [pget/2, pget/3]).
+-import(rabbit_misc, [pget/2, pget/3, pset/3]).
 
 -rabbit_boot_step({?MODULE,
                    [{description, "shovel parameters"},
@@ -81,6 +82,16 @@ validate_amqp091_src(Def) ->
          _ ->
              ok
      end].
+
+obfuscate_uris_parameters(Def) ->
+  SrcURIs  = get_uris(<<"src-uri">>, Def),
+  ObfuscatedSrcURIsDef = pset(<<"src-uri">>, obfuscate_uris(SrcURIs), Def),
+  DestURIs  = get_uris(<<"dest-uri">>, Def),
+  ObfuscatedDef = pset(<<"dest-uri">>, obfuscate_uris(DestURIs), ObfuscatedSrcURIsDef),
+  ObfuscatedDef.
+
+obfuscate_uris(URIs) ->
+  [credentials_obfuscation:encrypt(URI) || URI <- URIs].
 
 validate_amqp091_dest(Def) ->
     [case pget2(<<"dest-exchange">>, <<"dest-queue">>, Def) of
@@ -279,7 +290,7 @@ parse_dest(VHostName, ClusterName, Def, SourceHeaders) ->
     end.
 
 parse_amqp10_dest({_VHost, _Name}, _ClusterName, Def, SourceHeaders) ->
-    Uris = get_uris(<<"dest-uri">>, Def),
+    Uris = get_unencrypted_uris(<<"dest-uri">>, Def),
     Address = pget(<<"dest-address">>, Def),
     Properties =
         rabbit_data_coercion:to_proplist(
@@ -305,7 +316,7 @@ parse_amqp10_dest({_VHost, _Name}, _ClusterName, Def, SourceHeaders) ->
      }.
 
 parse_amqp091_dest({VHost, Name}, ClusterName, Def, SourceHeaders) ->
-    DestURIs  = get_uris(<<"dest-uri">>,      Def),
+    DestURIs  = get_unencrypted_uris(<<"dest-uri">>,      Def),
     DestX     = pget(<<"dest-exchange">>,     Def, none),
     DestXKey  = pget(<<"dest-exchange-key">>, Def, none),
     DestQ     = pget(<<"dest-queue">>,        Def, none),
@@ -373,7 +384,7 @@ parse_amqp091_dest({VHost, Name}, ClusterName, Def, SourceHeaders) ->
                 }, Details).
 
 parse_amqp10_source(Def) ->
-    Uris = get_uris(<<"src-uri">>, Def),
+    Uris = get_unencrypted_uris(<<"src-uri">>, Def),
     Address = pget(<<"src-address">>, Def),
     DeleteAfter = pget(<<"src-delete-after">>, Def, <<"never">>),
     PrefetchCount = pget(<<"src-prefetch-count">>, Def, 1000),
@@ -386,7 +397,7 @@ parse_amqp10_source(Def) ->
        consumer_args => []}, Headers}.
 
 parse_amqp091_source(Def) ->
-    SrcURIs  = get_uris(<<"src-uri">>, Def),
+    SrcURIs  = get_unencrypted_uris(<<"src-uri">>, Def),
     SrcX     = pget(<<"src-exchange">>,Def, none),
     SrcXKey  = pget(<<"src-exchange-key">>, Def, <<>>), %% [1]
     SrcQ     = pget(<<"src-queue">>, Def, none),
@@ -428,6 +439,11 @@ get_uris(Key, Def) ->
                B when is_binary(B) -> [B];
                L when is_list(L)   -> L
            end,
+    [binary_to_list(URI) || URI <- URIs].
+
+get_unencrypted_uris(Key, Def) ->
+    ObfuscatedURIs =  pget(Key, Def),
+    URIs = [credentials_obfuscation:decrypt(ObfuscatedURI) || ObfuscatedURI <- ObfuscatedURIs],
     [binary_to_list(URI) || URI <- URIs].
 
 translate_ack_mode(<<"on-confirm">>) -> on_confirm;

--- a/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
+++ b/deps/rabbitmq_shovel/src/rabbit_shovel_parameters.erl
@@ -442,7 +442,7 @@ get_uris(Key, Def) ->
     [binary_to_list(URI) || URI <- URIs].
 
 get_unencrypted_uris(Key, Def) ->
-    ObfuscatedURIs =  pget(Key, Def),
+    ObfuscatedURIs = pget(Key, Def),
     URIs = [credentials_obfuscation:decrypt(ObfuscatedURI) || ObfuscatedURI <- ObfuscatedURIs],
     [binary_to_list(URI) || URI <- URIs].
 

--- a/deps/rabbitmq_shovel/test/parameters_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/parameters_SUITE.erl
@@ -43,9 +43,18 @@ groups() ->
 %% -------------------------------------------------------------------
 
 init_per_suite(Config) ->
+    {ok, _} = application:ensure_all_started(credentials_obfuscation),
+    Secret = crypto:strong_rand_bytes(128),
+    ok = credentials_obfuscation:set_secret(Secret),
     Config.
 
 end_per_suite(Config) ->
+    case application:stop(credentials_obfuscation) of
+      ok ->
+        ok;
+      {error, {not_started, credentials_obfuscation}} ->
+        ok
+    end,
     Config.
 
 init_per_group(_, Config) ->
@@ -55,18 +64,9 @@ end_per_group(_, Config) ->
     Config.
 
 init_per_testcase(_Testcase, Config) ->
-  {ok, _} = application:ensure_all_started(credentials_obfuscation),
-  Secret = crypto:strong_rand_bytes(128),
-  ok = credentials_obfuscation:set_secret(Secret),
   Config.
 
 end_per_testcase(_Testcase, Config) ->
-  case application:stop(credentials_obfuscation) of
-    ok ->
-      ok;
-    {error, {not_started, credentials_obfuscation}} ->
-      ok
-  end,
   Config.
 
 

--- a/deps/rabbitmq_shovel/test/parameters_SUITE.erl
+++ b/deps/rabbitmq_shovel/test/parameters_SUITE.erl
@@ -54,9 +54,20 @@ init_per_group(_, Config) ->
 end_per_group(_, Config) ->
     Config.
 
-init_per_testcase(_Testcase, Config) -> Config.
+init_per_testcase(_Testcase, Config) ->
+  {ok, _} = application:ensure_all_started(credentials_obfuscation),
+  Secret = crypto:strong_rand_bytes(128),
+  ok = credentials_obfuscation:set_secret(Secret),
+  Config.
 
-end_per_testcase(_Testcase, Config) -> Config.
+end_per_testcase(_Testcase, Config) ->
+  case application:stop(credentials_obfuscation) of
+    ok ->
+      ok;
+    {error, {not_started, credentials_obfuscation}} ->
+      ok
+  end,
+  Config.
 
 
 %% -------------------------------------------------------------------
@@ -140,8 +151,9 @@ parse_amqp091_empty_proplists(_Config) ->
 
 
 test_parse_amqp091(Params) ->
+    ObfuscatedParams = rabbit_shovel_parameters:obfuscate_uris_parameters(Params),
     {ok, Result} = rabbit_shovel_parameters:parse({"vhost", "name"},
-                                                  "my-cluster", Params),
+                                                  "my-cluster", ObfuscatedParams),
     #{ack_mode := on_publish,
       name := "name",
       reconnect_delay := 1001,
@@ -165,8 +177,9 @@ test_parse_amqp091(Params) ->
     ok.
 
 test_parse_amqp091_with_blank_proprties(Params) ->
+    ObfuscatedParams = rabbit_shovel_parameters:obfuscate_uris_parameters(Params),
     {ok, Result} = rabbit_shovel_parameters:parse({"vhost", "name"},
-                                                  "my-cluster", Params),
+                                                  "my-cluster", ObfuscatedParams),
     #{ack_mode := on_publish,
       name := "name",
       reconnect_delay := 1001,
@@ -229,7 +242,7 @@ parse_amqp10(_Config) ->
                                             <<"message-ann-value">>}]},
          {<<"dest-properties">>, [{<<"user_id">>, <<"some-user">>}]}
         ],
-
+    ObfuscatedParams = rabbit_shovel_parameters:obfuscate_uris_parameters(Params),
     ?assertMatch(
        {ok, #{name := "my_shovel",
               ack_mode := on_publish,
@@ -252,7 +265,7 @@ parse_amqp10(_Config) ->
                        }
              }},
         rabbit_shovel_parameters:parse({"vhost", "my_shovel"}, "my-cluster",
-                                       Params)),
+                                       ObfuscatedParams)),
     ok.
 
 parse_amqp10_minimal(_Config) ->
@@ -266,6 +279,7 @@ parse_amqp10_minimal(_Config) ->
          {<<"dest-uri">>, <<"amqp://remotehost:5672">>},
          {<<"dest-address">>, <<"a-dest-queue">>}
         ],
+    ObfuscatedParams = rabbit_shovel_parameters:obfuscate_uris_parameters(Params),
     ?assertMatch(
        {ok, #{name := "my_shovel",
               ack_mode := on_confirm,
@@ -281,7 +295,7 @@ parse_amqp10_minimal(_Config) ->
                        }
              }},
         rabbit_shovel_parameters:parse({"vhost", "my_shovel"}, "my-cluster",
-                                       Params)),
+                                       ObfuscatedParams)),
     ok.
 
 validate_amqp10(_Config) ->


### PR DESCRIPTION
…words being logged on crashes

When a shovel is configured incorrectly (either with incorrect username/password, or the targeted broker is down or unreachable), rabbit_shovel_worker crashes with its full state including URIs with plain text passwords being logged in the crash log, and sometimes also in the default log. 


* This is an example of a crash log having password logged in plaintext:
```
2021-08-04 02:22:23 =SUPERVISOR REPORT====
     Supervisor: {<0.740.0>,rabbit_shovel_dyn_worker_sup}
     Context:    child_terminated
     Reason:     shutdown
     Offender:   [{pid,<0.860.0>},{id,{<<"/">>,<<"notWorkingShovel">>}},{mfargs,{rabbit_shovel_worker,start_link,[dynamic,{<<"/">>,<<"notWorkingShovel">>},[{<<"ack-mode">>,<<"on-confirm">>},{<<"dest-add-forward-headers">>,false},{<<"dest-protocol">>,<<"amqp091">>},{<<"dest-uri">>,<<"amqp://">>},{<<"src-delete-after">>,<<"never">>},{<<"src-protocol">>,<<"amqp091">>},{<<"src-queue">>,<<"test-shovel-queue">>},{<<"src-uri">>,<<"amqp://user:pass@wronghost.com:5671">>}]]}},{restart_type,{permanent,5}},{shutdown,4294967295},{child_type,worker}]
```
* When node is restarted, plain text password get logged in default log too:
```
2021-08-04 02:22:07.857 [info] <0.740.0> supervisor: {<0.740.0>,rabbit_shovel_dyn_worker_sup}, errorContext: child_terminated, reason: shutdown, offender: [{pid,<0.741.0>},{id,{<<"/">>,<<"notWorkingShovel">>}},{mfargs,{rabbit_shovel_worker,start_link,[dynamic,{<<"/">>,<<"notWorkingShovel">>},[{<<"ack-mode">>,<<"on-confirm">>},{<<"dest-add-forward-headers">>,false},{<<"dest-protocol">>,<<"amqp091">>},{<<"dest-uri">>,<<"amqp://">>},{<<"src-delete-after">>,<<"never">>},{<<"src-protocol">>,<<"amqp091">>},{<<"src-queue">>,<<"test-shovel-queue">>},{<<"src-uri">>,<<"amqp://user:pass@wronghost.com:5671">>}]]}},{restart_type,{permanent,5}},{shutdown,4294967295},{child_type,worker}]
```

The issue was reported in the past: https://github.com/rabbitmq/rabbitmq-server/issues/2709


## Proposed Changes

The following change is an implementation to avoid plain text passwords being logged with the shovel workers' states upon crashing. Specifically, the change is to only store obfuscated URIs in the shovel workers' states and deobfuscate them when accessed. As a result, when shovel workers crash, the passwords will not be logged in plain text. The error logs from the shovel plugin will tell users what went wrong.

For example, when the targeted broker's DNS is not correct, the error message in default log indicates what the problem is:
```
2021-07-31 17:25:29.294574+00:00 [erro] <0.22741.5> Shovel 'notWorkingShovel' failed to connect (URI: amqp://wronghost.com:5671): unknown host (failed to resolve hostname)
2021-07-31 17:25:29.294677+00:00 [erro] <0.22741.5> Shovel 'notWorkingShovel' has no more URIs to try for connection
2021-07-31 17:25:29.294727+00:00 [erro] <0.22741.5> Shovel 'notWorkingShovel' could not connect to source
```

The crash log will not show the password in plain text:
```
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>     supervisor: {<0.22740.5>,rabbit_shovel_dyn_worker_sup}
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>     errorContext: child_terminated
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>     reason: shutdown
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>     offender: [{pid,<0.22741.5>},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                {id,{<<"/">>,<<"notWorkingShovel">>}},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                {mfargs,
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                    {rabbit_shovel_worker,start_link,
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                        [dynamic,
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                         {<<"/">>,<<"notWorkingShovel">>},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                         [{<<"dest-uri">>,
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                           [{encrypted,
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                                <<"HtDNAVY31TtCO2I1UByk1OWwXn5AfSl/zouMBki3NG1nnAWxF3WpfEu7lmz//btl">>}]},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                          {<<"src-uri">>,
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                           [{encrypted,
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                                <<"m1B4OoxBTldD2Xo5VuDepCsfcmALH/mM61IuATxMBvS+MPJqxfUVfCtLh+ZCikouPmdGX1CkoOgVh+UIlmFN05ByuYsM3GmvcxjMjAvIvRo=">>}]},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                          {<<"ack-mode">>,<<"on-confirm">>},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                          {<<"dest-add-forward-headers">>,false},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                          {<<"dest-protocol">>,<<"amqp091">>},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                          {<<"src-delete-after">>,<<"never">>},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                          {<<"src-protocol">>,<<"amqp091">>},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                          {<<"src-queue">>,<<"test-shovel-queue">>}]]}},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                {restart_type,{permanent,5}},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                {shutdown,4294967295},
2021-07-31 17:25:29.294843+00:00 [erro] <0.22740.5>                {child_type,worker}]

```



## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

## Further Comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
