### PR TITLE
Support configure max sync throughput in CMQs

### DIFF
--- a/deps/rabbit/priv/schema/rabbit.schema
+++ b/deps/rabbit/priv/schema/rabbit.schema
@@ -1021,6 +1021,23 @@ end}.
 {mapping, "mirroring_sync_batch_size", "rabbit.mirroring_sync_batch_size",
     [{datatype, bytesize}, {validators, ["mirroring_sync_batch_size"]}]}.
 
+%% Mirror sync max throughput (in bytes) per second.
+%% Supported unit symbols:
+%% k, kiB: kibibytes (2^10 - 1,024 bytes)
+%% M, MiB: mebibytes (2^20 - 1,048,576 bytes)
+%% G, GiB: gibibytes (2^30 - 1,073,741,824 bytes)
+%% kB: kilobytes (10^3 - 1,000 bytes)
+%% MB: megabytes (10^6 - 1,000,000 bytes)
+%% GB: gigabytes (10^9 - 1,000,000,000 bytes)
+%%
+%% 0 means "no limit".
+%%
+%% {mirroring_sync_max_throughput, 0},
+
+{mapping, "mirroring_sync_max_throughput", "rabbit.mirroring_sync_max_throughput", [
+    {datatype, [integer, string]}
+]}.
+
 %% Peer discovery backend used by cluster formation.
 %%
 

--- a/deps/rabbit/src/rabbit_mirror_queue_sync.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_sync.erl
@@ -118,7 +118,7 @@ maybe_master_batch_send({_, _, _, {Curr, _Len}, _}, BatchSize)
     when Curr rem BatchSize =:= 0 ->
     true;
 maybe_master_batch_send({_, _, {TotalBytes, _, SyncThroughput}, {_Curr, _Len}, _}, _BatchSize)
-    when TotalBytes >= SyncThroughput ->
+    when TotalBytes > SyncThroughput ->
     true;
 maybe_master_batch_send(_Acc, _BatchSize) ->
     false.
@@ -131,7 +131,7 @@ bq_fold(FoldFun, FoldAcc, Args, BQ, BQS) ->
     end.
 
 append_to_acc(Msg, MsgProps, Unacked, {Batch, I, {_, _, 0}, {Curr, Len}, T}) ->
-    {[{Msg, MsgProps, Unacked} | Batch], I, {-1, 0, 0}, {Curr + 1, Len}, T};
+    {[{Msg, MsgProps, Unacked} | Batch], I, {0, 0, 0}, {Curr + 1, Len}, T};
 append_to_acc(Msg, MsgProps, Unacked, {Batch, I, {TotalBytes, LastCheck, SyncThroughput}, {Curr, Len}, T}) ->
     {[{Msg, MsgProps, Unacked} | Batch], I, {TotalBytes + rabbit_basic:msg_size(Msg), LastCheck, SyncThroughput}, {Curr + 1, Len}, T}.
 

--- a/deps/rabbit/src/rabbit_mirror_queue_sync.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_sync.erl
@@ -177,9 +177,8 @@ pause_queue_sync(Delta) ->
 %% The amount of time to pause queue sync is the different between time needed to broadcast TotalBytes at max throughput
 %% and the elapsed time (Interval).
 get_time_diff(TotalBytes, Interval, SyncThroughput) ->
-    UsedThroughput = round(TotalBytes * 1000 / Interval),
-    rabbit_log_mirroring:debug("Total ~p bytes has been sent over last ~p ms. Effective sync througput: ~p", [TotalBytes, Interval, UsedThroughput]),
-    max(round(UsedThroughput/SyncThroughput * 1000 - Interval), 0).
+    rabbit_log_mirroring:debug("Total ~p bytes has been sent over last ~p ms. Effective sync througput: ~p", [TotalBytes, Interval, round(TotalBytes * 1000 / Interval)]),
+    max(round(TotalBytes/SyncThroughput * 1000 - Interval), 0).
 
 master_done({Syncer, Ref, _Log, _HandleInfo, _EmitStats, Parent}, BQS) ->
     receive

--- a/deps/rabbit/src/rabbit_mirror_queue_sync.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_sync.erl
@@ -9,9 +9,14 @@
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 
--export([master_prepare/4, master_go/8, slave/7, conserve_resources/3]).
+-export([master_prepare/4, master_go/9, slave/7, conserve_resources/3]).
+
+%% Export for UTs
+-export([maybe_master_batch_send/2, get_time_diff/3]).
 
 -define(SYNC_PROGRESS_INTERVAL, 1000000).
+
+-define(SYNC_THROUGHPUT_EVAL_INTERVAL_MILLIS, 50).
 
 %% There are three processes around, the master, the syncer and the
 %% slave(s). The syncer is an intermediary, linked to the master in
@@ -67,23 +72,24 @@ master_prepare(Ref, QName, Log, SPids) ->
                       rabbit_mirror_queue_master:stats_fun(),
                       rabbit_mirror_queue_master:stats_fun(),
                       non_neg_integer(),
+                      non_neg_integer(),
                       bq(), bqs()) ->
                           {'already_synced', bqs()} | {'ok', bqs()} |
                           {'cancelled', bqs()} |
                           {'shutdown', any(), bqs()} |
                           {'sync_died', any(), bqs()}.
 
-master_go(Syncer, Ref, Log, HandleInfo, EmitStats, SyncBatchSize, BQ, BQS) ->
+master_go(Syncer, Ref, Log, HandleInfo, EmitStats, SyncBatchSize, SyncThroughput, BQ, BQS) ->
     Args = {Syncer, Ref, Log, HandleInfo, EmitStats, rabbit_misc:get_parent()},
     receive
         {'EXIT', Syncer, normal} -> {already_synced, BQS};
         {'EXIT', Syncer, Reason} -> {sync_died, Reason, BQS};
         {ready, Syncer}          -> EmitStats({syncing, 0}),
-                                    master_batch_go0(Args, SyncBatchSize,
+                                    master_batch_go0(Args, SyncBatchSize, SyncThroughput,
                                                      BQ, BQS)
     end.
 
-master_batch_go0(Args, BatchSize, BQ, BQS) ->
+master_batch_go0(Args, BatchSize, SyncThroughput, BQ, BQS) ->
     FoldFun =
         fun (Msg, MsgProps, Unacked, Acc) ->
                 Acc1 = append_to_acc(Msg, MsgProps, Unacked, Acc),
@@ -92,24 +98,27 @@ master_batch_go0(Args, BatchSize, BQ, BQS) ->
                     false -> {cont, Acc1}
                 end
         end,
-    FoldAcc = {[], 0, {0, BQ:depth(BQS)}, erlang:monotonic_time()},
+    FoldAcc = {[], 0, {0, erlang:monotonic_time(), SyncThroughput}, {0, BQ:depth(BQS)}, erlang:monotonic_time()},
     bq_fold(FoldFun, FoldAcc, Args, BQ, BQS).
 
 master_batch_send({Syncer, Ref, Log, HandleInfo, EmitStats, Parent},
-                  {Batch, I, {Curr, Len}, Last}) ->
+                  {Batch, I, {TotalBytes, LastCheck, SyncThroughput}, {Curr, Len}, Last}) ->
     T = maybe_emit_stats(Last, I, EmitStats, Log),
     HandleInfo({syncing, I}),
     handle_set_maximum_since_use(),
     SyncMsg = {msgs, Ref, lists:reverse(Batch)},
-    NewAcc = {[], I + length(Batch), {Curr, Len}, T},
+    NewAcc = {[], I + length(Batch), {TotalBytes, LastCheck, SyncThroughput}, {Curr, Len}, T},
     master_send_receive(SyncMsg, NewAcc, Syncer, Ref, Parent).
 
 %% Either send messages when we reach the last one in the queue or
 %% whenever we have accumulated BatchSize messages.
-maybe_master_batch_send({_, _, {Len, Len}, _}, _BatchSize) ->
+maybe_master_batch_send({_, _, _, {Len, Len}, _}, _BatchSize) ->
     true;
-maybe_master_batch_send({_, _, {Curr, _Len}, _}, BatchSize)
-  when Curr rem BatchSize =:= 0 ->
+maybe_master_batch_send({_, _, _, {Curr, _Len}, _}, BatchSize)
+    when Curr rem BatchSize =:= 0 ->
+    true;
+maybe_master_batch_send({_, _, {TotalBytes, _, SyncThroughput}, {_Curr, _Len}, _}, _BatchSize)
+    when TotalBytes >= SyncThroughput ->
     true;
 maybe_master_batch_send(_Acc, _BatchSize) ->
     false.
@@ -121,8 +130,8 @@ bq_fold(FoldFun, FoldAcc, Args, BQ, BQS) ->
         {_,                   BQS1} -> master_done(Args, BQS1)
     end.
 
-append_to_acc(Msg, MsgProps, Unacked, {Batch, I, {Curr, Len}, T}) ->
-    {[{Msg, MsgProps, Unacked} | Batch], I, {Curr + 1, Len}, T}.
+append_to_acc(Msg, MsgProps, Unacked, {Batch, I, {TotalBytes, LastCheck, SyncThroughput}, {Curr, Len}, T}) ->
+    {[{Msg, MsgProps, Unacked} | Batch], I, {TotalBytes + rabbit_basic:msg_size(Msg), LastCheck, SyncThroughput}, {Curr + 1, Len}, T}.
 
 master_send_receive(SyncMsg, NewAcc, Syncer, Ref, Parent) ->
     receive
@@ -131,10 +140,42 @@ master_send_receive(SyncMsg, NewAcc, Syncer, Ref, Parent) ->
                                     gen_server2:reply(From, ok),
                                     {stop, cancelled};
         {next, Ref}              -> Syncer ! SyncMsg,
-                                    {cont, NewAcc};
+                                    {Msgs, I , {TotalBytes, LastCheck, SyncThroughput}, {Curr, Len}, T} = NewAcc,
+                                    {NewTotalBytes, NewLastCheck} = maybe_throttle_sync_throughput(TotalBytes, LastCheck, SyncThroughput),
+                                    {cont, {Msgs, I, {NewTotalBytes, NewLastCheck, SyncThroughput}, {Curr, Len}, T}};
         {'EXIT', Parent, Reason} -> {stop, {shutdown,  Reason}};
         {'EXIT', Syncer, Reason} -> {stop, {sync_died, Reason}}
     end.
+
+maybe_throttle_sync_throughput(_ , _, 0) ->
+    {0, erlang:monotonic_time()};
+maybe_throttle_sync_throughput(TotalBytes, LastCheck, SyncThroughput) ->
+    Interval = erlang:convert_time_unit(erlang:monotonic_time() - LastCheck, native, milli_seconds),
+    case Interval > ?SYNC_THROUGHPUT_EVAL_INTERVAL_MILLIS of
+        true  -> maybe_pause_sync(TotalBytes, Interval, SyncThroughput, LastCheck);
+        false -> {TotalBytes, LastCheck}
+    end.
+
+maybe_pause_sync(TotalBytes, Interval, SyncThroughput, LastCheck) ->
+    Delta = get_time_diff(TotalBytes, Interval, SyncThroughput),
+    pause_queue_sync(Delta, TotalBytes, LastCheck).
+
+pause_queue_sync(0, TotalBytes, LastCheck) ->
+    {TotalBytes, LastCheck};
+pause_queue_sync(Delta, _TotalBytes, _LastCheck) ->
+    timer:sleep(Delta),
+    {0, erlang:monotonic_time()}. %% reset TotalBytes counter and LastCheck.
+
+%% Sync throughput computation:
+%% - Total bytes have been sent since last check: TotalBytes
+%% - Used/Elapsed time since last check: Interval (in milliseconds)
+%% - Effective/Used throughput in bytes/s: TotalBytes/Interval * 1000.
+%% - When UsedThroughput > SyncThroughput -> we need to slow down to compensate over-used rate.
+%% The amount of time to pause queue sync is the different between time needed to broadcast TotalBytes at max throughput
+%% and the elapsed time (Interval).
+get_time_diff(TotalBytes, Interval, SyncThroughput) ->
+    UsedThroughput = round(TotalBytes * 1000 / Interval),
+    max(round(UsedThroughput/SyncThroughput * 1000 - Interval), 0).
 
 master_done({Syncer, Ref, _Log, _HandleInfo, _EmitStats, Parent}, BQS) ->
     receive

--- a/deps/rabbit/src/rabbit_mirror_queue_sync.erl
+++ b/deps/rabbit/src/rabbit_mirror_queue_sync.erl
@@ -12,7 +12,7 @@
 -export([master_prepare/4, master_go/9, slave/7, conserve_resources/3]).
 
 %% Export for UTs
--export([maybe_master_batch_send/2, get_time_diff/3]).
+-export([maybe_master_batch_send/2, get_time_diff/3, append_to_acc/4]).
 
 -define(SYNC_PROGRESS_INTERVAL, 1000000).
 
@@ -130,6 +130,8 @@ bq_fold(FoldFun, FoldAcc, Args, BQ, BQS) ->
         {_,                   BQS1} -> master_done(Args, BQS1)
     end.
 
+append_to_acc(Msg, MsgProps, Unacked, {Batch, I, {_, _, 0}, {Curr, Len}, T}) ->
+    {[{Msg, MsgProps, Unacked} | Batch], I, {-1, 0, 0}, {Curr + 1, Len}, T};
 append_to_acc(Msg, MsgProps, Unacked, {Batch, I, {TotalBytes, LastCheck, SyncThroughput}, {Curr, Len}, T}) ->
     {[{Msg, MsgProps, Unacked} | Batch], I, {TotalBytes + rabbit_basic:msg_size(Msg), LastCheck, SyncThroughput}, {Curr + 1, Len}, T}.
 

--- a/deps/rabbit/test/rabbit_mirror_queue_misc_SUITE.erl
+++ b/deps/rabbit/test/rabbit_mirror_queue_misc_SUITE.erl
@@ -1,0 +1,29 @@
+-module(rabbit_mirror_queue_misc_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() ->
+  [
+    default_max_sync_throughput
+  ].
+
+default_max_sync_throughput(_Config) ->
+  ?assertEqual(
+    0,
+    rabbit_mirror_queue_misc:default_max_sync_throughput()),
+  application:set_env(rabbit, mirroring_sync_max_throughput, 100),
+  ?assertEqual(
+    100,
+    rabbit_mirror_queue_misc:default_max_sync_throughput()),
+  application:set_env(rabbit, mirroring_sync_max_throughput, "100MiB"),
+  ?assertEqual(
+    100*1024*1024,
+    rabbit_mirror_queue_misc:default_max_sync_throughput()),
+  application:set_env(rabbit, mirroring_sync_max_throughput, "100MB"),
+  ?assertEqual(
+    100000000,
+    rabbit_mirror_queue_misc:default_max_sync_throughput()),
+  ok.

--- a/deps/rabbit/test/rabbit_mirror_queue_sync_SUITE.erl
+++ b/deps/rabbit/test/rabbit_mirror_queue_sync_SUITE.erl
@@ -1,0 +1,57 @@
+-module(rabbit_mirror_queue_sync_SUITE).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-compile(export_all).
+
+all() ->
+  [
+    maybe_master_batch_send,
+    get_time_diff
+  ].
+
+maybe_master_batch_send(_Config) ->
+  SyncBatchSize = 4096,
+  SyncThroughput = 2000,
+  QueueLen = 10000,
+  ?assertEqual(
+    true, %% Message reach the last one in the queue
+    rabbit_mirror_queue_sync:maybe_master_batch_send({[], 0, {0, 0, SyncThroughput}, {QueueLen, QueueLen}, 0}, SyncBatchSize)),
+  ?assertEqual(
+    true, %% # messages batched is less than batch size; and total message size has reached the batch size
+    rabbit_mirror_queue_sync:maybe_master_batch_send({[], 0, {0, 0, SyncThroughput}, {SyncBatchSize, QueueLen}, 0}, SyncBatchSize)),
+  TotalBytes0 = SyncThroughput + 1,
+  Curr0 = 1,
+  ?assertEqual(
+    true,  %% Total batch size exceed max sync throughput
+    rabbit_mirror_queue_sync:maybe_master_batch_send({[], 0, {TotalBytes0, 0, SyncThroughput}, {Curr0, QueueLen}, 0}, SyncBatchSize)),
+  TotalBytes1 = 1,
+  Curr1 = 1,
+  ?assertEqual(
+    false, %% # messages batched is less than batch size; and total bytes is less than sync throughput
+    rabbit_mirror_queue_sync:maybe_master_batch_send({[], 0, {TotalBytes1, 0, SyncThroughput}, {Curr1, QueueLen}, 0}, SyncBatchSize)),
+  ok.
+
+get_time_diff(_Config) ->
+  TotalBytes0 = 100,
+  Interval0 = 1000, %% ms
+  MaxSyncThroughput0 = 100,  %% bytes/s
+  ?assertEqual(%% Used throughput = 100 / 1000 * 1000 = 100 bytes/s; matched max throughput
+    0, %% => no need to pause queue sync
+    rabbit_mirror_queue_sync:get_time_diff(TotalBytes0, Interval0, MaxSyncThroughput0)),
+
+  TotalBytes1 = 100,
+  Interval1 = 1000, %% ms
+  MaxSyncThroughput1 = 200,  %% bytes/s
+  ?assertEqual( %% Used throughput = 100 / 1000 * 1000 = 100 bytes/s; less than max throughput
+    0, %% => no need to pause queue sync
+    rabbit_mirror_queue_sync:get_time_diff(TotalBytes1, Interval1, MaxSyncThroughput1)),
+
+  TotalBytes2 = 100,
+  Interval2 = 1000, %% ms
+  MaxSyncThroughput2 = 50,  %% bytes/s
+  ?assertEqual( %% Used throughput = 100 / 1000 * 1000 = 100 bytes/s; greater than max throughput
+    1000, %% => pause queue sync for 1000 ms
+    rabbit_mirror_queue_sync:get_time_diff(TotalBytes2, Interval2, MaxSyncThroughput2)),
+  ok.

--- a/deps/rabbit/test/rabbit_mirror_queue_sync_SUITE.erl
+++ b/deps/rabbit/test/rabbit_mirror_queue_sync_SUITE.erl
@@ -73,7 +73,7 @@ append_to_acc(_Config) ->
   SyncThroughput_0 = 0,
   FoldAcc1 = {[], 0, {0, erlang:monotonic_time(), SyncThroughput_0}, {0, BQDepth}, erlang:monotonic_time()},
   {_, _, {TotalBytes1, _, _}, _, _} = rabbit_mirror_queue_sync:append_to_acc(Msg, {}, false, FoldAcc1),
-  ?assertEqual(-1, TotalBytes1),  %% Skipping calculating TotalBytes for the pending batch as SyncThroughput is 0.
+  ?assertEqual(0, TotalBytes1),  %% Skipping calculating TotalBytes for the pending batch as SyncThroughput is 0.
 
   SyncThroughput = 100,
   FoldAcc2 = {[], 0, {0, erlang:monotonic_time(), SyncThroughput}, {0, BQDepth}, erlang:monotonic_time()},


### PR DESCRIPTION
## Proposed Changes

We would like to propose a backward compatible change in order to reduce memory utilization during classic mirrored queue sync. 

Specifically, in addition to the existing `mirroring_sync_batch_size` configuration key, which controls maximum number of messages per sync batch, we propose to add  a new configuration key `mirroring_sync_max_throughput` in bytes (per second) to control maximum synchronization throughput. The `syncer` at the primary node will make sure the throughput of messages being synchronized does not exceed the value configured. This will give mirroring nodes sufficient time to page messages being synchronized to disk and quickly free up memory. 

The motivation for this is that, in our test with a 3-node cluster on AWS with data volumes using [EBS gp2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html) (maximum disk write throughput is 250MiB/s), we observe memory utilization during queue sync is quite high, often leading to a memory alarm. We suspect that when disk write throughput is low, mirroring nodes take time to page messages to disk while the syncer keeps broadcasting messages at a higher rate. As a result, most messages are kept in memory on the mirror(s) and are waiting to be paged to disk leading to high memory usage. 

With this change, If the max sync throughput value is set to less than the write throughput of data volumes, (i.e., the primary node never flush data at a speed higher than disk write speed), it will help reduce memory utilization at mirroring node significantly. The new configuration will be disabled by default (`mirroring_sync_max_throughput = 0`) to ensure *backward compatibility*. I.e., nothing changes to existing/running RabbitMQ clusters. Users will have to explicitly set sync throughput to enable the feature.

Here are samples of memory utilization at the mirroring node and the primary node with different message sizes in tests using RabbitMQ 3.8.22 in a cluster with [EBS gp2 volume](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-volume-types.html) compared with the limit sync throughput feature:

## Medium/average message size, e.g., 640k 
### RabbitMQ 3.8.22
A test with RabbitMQ 3.8.22 using batch size of 128 shows memory consumption at mirroring node is very high (around memory alarm level); (memory utilization at the primary node is good however).

* Memory consumption during queue sync at the mirroring node is high

![image(3)](https://user-images.githubusercontent.com/59986634/145267734-65bd8b79-7105-48cb-b314-2213091b0fb1.png)

* Memory consumption during queue sync at the primary node looks good.

![image(4)](https://user-images.githubusercontent.com/59986634/145267832-2efd905c-610f-415d-a63d-a0bd484ff577.png)

### Limit sync throughput
We tested this change with `mirroring_sync_max_throughput = 150MiB` with similar setting, memory consumption is low at both mirroring node and primary node. 

* Memory consumption during queue sync at the mirroring node:

![image(5)](https://user-images.githubusercontent.com/59986634/145267870-46ced345-70ce-4442-bf08-be0c58386d32.png)

* Memory consumption during queue sync at the primary node is low too

![image(6)](https://user-images.githubusercontent.com/59986634/145267904-7b92ddec-bc61-4ade-a1a8-fe89f41e79f9.png)

## Large message size, e.g., 10MiB 

A test with RabbitMQ 3.8.22 using batch size of 128 shows memory utilization is very high at both mirroring node and primary node.

### RabbitMQ 3.8.22
* Memory consumption during queue sync at the mirroring node is high

![image(7)](https://user-images.githubusercontent.com/59986634/145267956-b1135735-1392-4a27-8aad-2671299e6066.png)

* Memory consumption during queue sync at the primary node is high too.

![image(8)](https://user-images.githubusercontent.com/59986634/145267990-81afd7b4-f01b-4b26-a7f7-889b84894429.png)

### Limit sync throughput
We tested with `mirroring_sync_max_throughput = 150MiB`, memory consumption drops significantly at both mirroring node and primary node. 

* Memory consumption during queue sync at the mirroring node dropped significantly.

![image(9)](https://user-images.githubusercontent.com/59986634/145268018-ec75548e-33ed-4378-b9d7-65c2b760f59f.png)

* Memory consumption during queue sync at the primary node is low as well

![image(10)](https://user-images.githubusercontent.com/59986634/145268054-70c1c3f0-306f-4724-b366-90ef2ba0b33b.png)

We also conducted tests with various settings such as using default batch size of 4096 as well as with smaller message sizes; they all show that when sync throughput is limited to a lower level of disk write throughput at mirroring nodes, memory consumed by queue sync processes significantly improves.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)
- [ ] Build system and/or CI

## Checklist

_Put an `x` in the boxes that apply.
You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask on the mailing list.
We're here to help!
This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All tests pass locally with my changes
- [ ] If relevant, I have added necessary documentation to https://github.com/rabbitmq/rabbitmq-website
     - We will submit a separate PR for updating doc once this change is approved/merged. 
- [ ] If relevant, I have added this change to the first version(s) in release-notes that I expect to introduce it

